### PR TITLE
Add Detection Resources page for open-source NHI tooling

### DIFF
--- a/2025/docs/detection-resources.md
+++ b/2025/docs/detection-resources.md
@@ -1,0 +1,38 @@
+# Open-Source Detection Resources
+
+The NHI Top 10 describes what can go wrong. This page indexes free, open-source tooling that helps organizations *assess* their own exposure to those risks.
+
+Listing here is not an endorsement. It is a vendor-neutral, community-maintained index. Tools are added by pull request and must meet the inclusion criteria below. The same criteria apply to every entry, including the first.
+
+## Inclusion Criteria
+
+A tool may be listed if it:
+
+1. Is open source under an OSI-approved license.
+2. Is read-only by default where technically feasible, or clearly documents any write or remediation actions.
+3. Maps to at least one NHI Top 10 risk, stated explicitly in its entry.
+4. Documents how it handles collected metadata — where it is stored, and whether anything leaves the user's environment.
+
+## Entry Format
+
+Each tool is one row with these fields:
+
+| Field | Description |
+|---|---|
+| Tool | Name and repository link |
+| NHI risk ID(s) | The NHI Top 10 risks the tool's checks map to |
+| Identity types | e.g. GitHub App, PAT, OAuth app, service account, cloud workload identity, CI/CD token |
+| Environment(s) | e.g. GitHub, Entra ID, Google Workspace, AWS, Kubernetes |
+| Access | Permissions required; read-only (yes/no) |
+| Evidence produced | What it surfaces (e.g. stale owner, unused credential, excessive scope, missing rotation) |
+| Blind spots / false positives | Known limitations |
+| Metadata handling | Where collected data is stored and whether it leaves the environment |
+| License & maintenance | License; whether actively maintained |
+
+## Tools
+
+Add tools below via pull request, one row per tool, in the format above. Each entry must meet the inclusion criteria.
+
+| Tool | NHI risk ID(s) | Identity types | Environment(s) | Access | Evidence produced | Blind spots / false positives | Metadata handling | License & maintenance |
+|---|---|---|---|---|---|---|---|---|
+| *Tool name + repo* | *NHI1, NHI5* | *GitHub App, PAT* | *GitHub* | *read-only* | *stale / over-scoped credentials* | *…* | *local; no telemetry* | *MIT; active* |

--- a/2025/mkdocs.yml
+++ b/2025/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
   - NHI8:2025 Environment Isolation: 8-environment-isolation.md
   - NHI9:2025 NHI Reuse: 9-nhi-reuse.md
   - NHI10:2025 Human Use of NHI: 10-human-use-of-nhi.md
+  - Detection Resources: detection-resources.md
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
Addresses #36.

This adds a vendor-neutral **Detection Resources** page that indexes open-source tooling for *assessing* exposure to the NHI Top 10 risks.

Per the discussion on #36, this PR is intentionally **framework only**:

- Inclusion criteria (open source, read-only by default, explicit NHI mapping, documented metadata handling)
- A fixed per-tool entry schema
- An empty tools table with a format example

It deliberately does **not** add any specific tool, so the inclusion criteria are agreed before the first entry lands and the page reads as a community index rather than a launch slot. @abhishek20c plans to add `gh-iga` as the first worked entry against this schema in a follow-up.

Also adds one `nav` line in `2025/mkdocs.yml`.

This is a starting point — happy to adjust structure, placement, or fields. @TalAstrix, would a separate page like this fit how you'd like detection guidance organized, or would you prefer it folded into the individual risk pages?
